### PR TITLE
Corrected install failure in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,13 @@
    "name" : "MulleObjC",
    "version" : "0.18.0",
    "description" : "💎 A collection of Objective-C root classes for mulle-objc",
-   "homepage" : "https://github.com/mulle-kybernetik-tv/MulleObjC
-https://github.com/mulle-objc/MulleObjC",
-   "bugs" : "https://github.com/mulle-kybernetik-tv/MulleObjC
-https://github.com/mulle-objc/MulleObjC/issues",
+   "homepage" : "https://github.com/mulle-objc/MulleObjC",
+   "bugs" : "https://github.com/mulle-objc/MulleObjC/issues",
    "keywords" : [],
    "license" : "BSD-3-Clause",
    "repository" : {
       "type" : "git",
-      "url" : "mulle-kybernetik-tv/MulleObjC
-mulle-objc/MulleObjC"
+      "url" : "mulle-objc/MulleObjC"
    },
    "dependencies" : {
       "mulle-objc-runtime" : "mulle-objc/mulle-objc-runtime",


### PR DESCRIPTION
Fixed:

```
npm ERR! code EJSONPARSE
npm ERR! path /home/bugravirgomercury8/Desktop/objcthings/MulleObjC/package.json
npm ERR! JSON.parse Unexpected token 
npm ERR! JSON.parse  in JSON at position 198 while parsing '{
npm ERR! JSON.parse    "name" : "MulleObjC",
npm ERR! JSON.parse    "version" '
npm ERR! JSON.parse Failed to parse JSON data.
npm ERR! JSON.parse Note: package.json must be actual JSON, not just JavaScript.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/bugravirgomercury8/.npm/_logs/2021-04-03T11_35_22_507Z-debug.log
```

Tidied up package.json and fixed the error above.